### PR TITLE
Fix slack link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -144,7 +144,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <strong>Slack</strong>
         <p>Stay up to date with the latest Blueoil news.</p>
         <div class="communityLink">
-          <a href="https://join.slack.com/t/blue-oil/shared_invite/enQtNDU5MDA5NTAzMjgyLTk4ZjZjYzRhOTBiOGZlOGY1MmMzMjU2ODg4MWE2NjY5YzI1ODRlNmQ4ZDgwN2I1YWE2ZTdjN2ZmNGVjZjg2MGU" target="_blank">
+          <a href="https://join.slack.com/t/blue-oil/shared_invite/enQtNDU5MDA5NTAzMjgyLTQyMjk4YjMxOWQyMGIzODkwZjQ3MWQ1NDc4ODIxNmJiMjY4MTAwYjJiZmJlZjlmNjBjMzE4OWM1MWUxYThmNmM" target="_blank">
             <svg viewBox="0 0 24 24">
               <g>
                 <title>Slack</title>


### PR DESCRIPTION
The slack invitation link has expired.
Therefore regenerated it.